### PR TITLE
Feature/fix setup typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: install test
 
 clean:
 	rm -rf sdc/rabbit/doc/html
-	rm -v dist/sdc-rabbit-python-*.tar.gz
+	rm -v dist/sdc-rabbit-*.tar.gz
 
 install:
 	pip3 install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: install test
 
 clean:
 	rm -rf sdc/rabbit/doc/html
-	rm -v dist/sdc-rabbit.tar.gz
+	rm -v dist/sdc-rabbit-*.tar.gz
 
 install:
 	pip3 install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: install test
 
 clean:
 	rm -rf sdc/rabbit/doc/html
-	rm -v dist/sdc-rabbit-*.tar.gz
+	rm -v dist/sdc-rabbit.tar.gz
 
 install:
 	pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# sdc-rabbit-python
+# sdc-rabbit
 
-[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit-python.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-rabbit-python) 
-[![codecov](https://codecov.io/gh/ONSdigital/sdc-rabbit-python/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/sdc-rabbit-python)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/043810e79dac47759cc661361a8af12b)](https://www.codacy.com/app/ONS/sdc-rabbit-python?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-rabbit-python&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-rabbit) 
+[![codecov](https://codecov.io/gh/ONSdigital/sdc-rabbit/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/sdc-rabbit)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/043810e79dac47759cc661361a8af12b)](https://www.codacy.com/app/ONS/sdc-rabbit?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-rabbit&amp;utm_campaign=Badge_Grade)
 
 Common code for SDC Pika-based services that interact with RabbitMQ.
 
-## sdc-rabbit-python
+## sdc-rabbit
 
 A common source code library for SDC apps that use Pika to interact with RabbitMQ.
 Apps wishing to use this service should use pip's VCS aware install method::
 
 ```Shell
-    $ pip install git+git://github.com/ONSDigital/sdc-rabbit-python.git@master
+    $ pip install git+git://github.com/ONSDigital/sdc-rabbit.git@master
 ```
 
 For production deployments a tag should be referenced, rather than master.

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,12 @@ installRequirements = [
 ]
 
 setup(
-    name="sdc-rabbit-python",
+    name="sdc-rabbit",
     version=version,
     description="A shared library for SDC services that interact with RabbitMQ using Pika",
     author="J Gardiner",
     author_email="james@jgardiner.co.uk",
-    url="https://github.com/ONSdigital/sdxc-rabbit-python",
+    url="https://github.com/ONSdigital/sdc-rabbit",
     long_description=__doc__,
     classifiers=[
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,6 @@ setup(
         "console_scripts": [
         ],
     },
-    zip_safe=False
+    zip_safe=False,
+    namespace_packages=["sdc"],
 )


### PR DESCRIPTION
This pull request fixes a typo in the setup.py file, where `sdc` was written `sdxc`. It also adds `namespace_packages=['sdc']` to the setup.py file, closing #6.