### PR TITLE
Remove basic config

### DIFF
--- a/sdc/rabbit/publisher.py
+++ b/sdc/rabbit/publisher.py
@@ -6,7 +6,6 @@ from structlog import wrap_logger
 
 from sdc.rabbit.exceptions import PublishMessageError
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 logger = wrap_logger(logger)
 


### PR DESCRIPTION
This pull request removes the calls to basicConfig, which allows end users to configure logging as required.