### PR TITLE
Add a TypeError handler to consumer, additional tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### Unreleased
+- Better exception handling of TypeErrors in consumer module when the `headers` attribute was not set in a message's properties.
 
 ### 1.0.2 2017-09-07
 - Bug fix release. Removes an issue where an additional keyword argument was being passed to the logger, causing an exception.

--- a/sdc/rabbit/consumers.py
+++ b/sdc/rabbit/consumers.py
@@ -453,9 +453,9 @@ class MessageConsumer(TornadoConsumer):
         : returns: tx_id of survey response
         : rtype: str
         """
-        tx = properties.headers['tx_id']
-        logger.info("Retrieved tx_id from message properties: tx_id={}".format(tx))
-        return tx
+        tx_id = properties.headers['tx_id']
+        logger.info("Retrieved tx_id from message properties: tx_id={}".format(tx_id))
+        return tx_id
 
     def __init__(self,
                  durable_queue,
@@ -529,13 +529,18 @@ class MessageConsumer(TornadoConsumer):
                              action="rejected",
                              exception=str(e))
                 return None
+            except TypeError as e:
+                self.reject_message(basic_deliver.delivery_tag)
+                logger.error("Bad message properties - no headers",
+                             action="rejected",
+                             exception=str(e))
+                return None
         else:
             logger.debug("check_tx_id is False. Not checking tx_id for message.",
                          delivery_tag=basic_deliver.delivery_tag)
             tx_id = None
 
         try:
-
             try:
                 self.process(body.decode("utf-8"), tx_id)
             except TypeError:

--- a/sdc/rabbit/test/test_consumer.py
+++ b/sdc/rabbit/test/test_consumer.py
@@ -32,6 +32,7 @@ class TestSdxConsumer(unittest.TestCase):
 
         self.props = DotDict({'headers': {'tx_id': 'test'}})
         self.props_no_tx_id = DotDict({'headers': {}})
+        self.props_no_headers = DotDict({})
         self.props_no_x_delivery_count = DotDict({'headers': {'tx_id': 'test'}})
         self.basic_deliver = DotDict({'delivery_tag': 'test'})
         self.body = json.loads('"{test message}"')
@@ -65,6 +66,9 @@ class TestSdxConsumer(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.consumer.tx_id(self.props_no_tx_id)
 
+        with self.assertRaises(TypeError):
+            self.consumer.tx_id(self.props_no_headers)
+
     def test_on_message_txid_key_error_returns_none(self):
         mock_method = 'sdc.rabbit.AsyncConsumer.reject_message'
         with mock.patch(mock_method) as barMock:
@@ -73,6 +77,17 @@ class TestSdxConsumer(unittest.TestCase):
                                               self.basic_deliver,
                                               self.props_no_tx_id,
                                               'test')
+
+        self.assertEqual(result, None)
+
+    def test_on_message_headers_type_error_returns_none(self):
+        mock_method = 'sdc.rabbit.AsyncConsumer.reject_message'
+        with mock.patch(mock_method) as barMock:
+            barMock.return_value = None
+            result = self.consumer.on_message(self.consumer._channel,
+                                              self.basic_deliver,
+                                              self.props_no_headers,
+                                              'test'.encode())
 
         self.assertEqual(result, None)
 


### PR DESCRIPTION
This pull request introduces additional exception handling to the consumer module. Specifically, TypeErrors that happen when a message does not have a `headers` attribute in the message properties are correctly handled, i.e. the message is rejected and an `ERROR` level log line is emitted.