### PR TITLE
Log exceptions at exception level to log traceback

### DIFF
--- a/sdc/rabbit/consumers.py
+++ b/sdc/rabbit/consumers.py
@@ -80,7 +80,7 @@ class AsyncConsumer:
                                              self.on_connection_open,
                                              stop_ioloop_on_close=False)
             except pika.exceptions.AMQPConnectionError as e:
-                logger.error("Connection error", exception=e)
+                logger.exception("Connection error")
                 count += 1
                 logger.error("Connection sleep", no_of_seconds=count)
                 time.sleep(count)
@@ -419,7 +419,7 @@ class TornadoConsumer(AsyncConsumer):
                                                                           self.on_connection_open,
                                                                           stop_ioloop_on_close=False)
             except pika.exceptions.AMQPConnectionError as e:
-                logger.error("Connection error", exception=e)
+                logger.exception("Connection error")
                 count += 1
                 logger.error("Connection sleep", no_of_seconds=count)
                 time.sleep(count)


### PR DESCRIPTION
This pull request removes `exception=e` kwargs in log lines in favour of logging at exception level, which automatically handles the logging of stack traces.