### PR TITLE
Feature/add high level exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sdc-rabbit
 
-[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-rabbit) 
+[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-rabbit)
 [![codecov](https://codecov.io/gh/ONSdigital/sdc-rabbit/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/sdc-rabbit)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/043810e79dac47759cc661361a8af12b)](https://www.codacy.com/app/ONS/sdc-rabbit?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-rabbit&amp;utm_campaign=Badge_Grade)
 
@@ -9,13 +9,7 @@ Common code for SDC Pika-based services that interact with RabbitMQ.
 ## sdc-rabbit
 
 A common source code library for SDC apps that use Pika to interact with RabbitMQ.
-Apps wishing to use this service should use pip's VCS aware install method::
-
-```Shell
-    $ pip install git+git://github.com/ONSDigital/sdc-rabbit.git@master
-```
-
-For production deployments a tag should be referenced, rather than master.
+To install, use `pip install sdc-rabbit`.
 
 ### Basic Use
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pika==0.10.0
+pika==0.11.2
 structlog==17.2.0
 tornado==4.5.1
 

--- a/sdc/rabbit/consumers.py
+++ b/sdc/rabbit/consumers.py
@@ -571,3 +571,11 @@ class MessageConsumer(TornadoConsumer):
                          action="nack",
                          exception=str(e),
                          tx_id=tx_id)
+
+        except Exception as e:
+            self.nack_message(basic_deliver.delivery_tag, tx_id=tx_id)
+            logger.exception("Unexpected exception occurred")
+            logger.error("Failed to process",
+                         action="nack",
+                         exception=str(e),
+                         tx_id=tx_id)

--- a/sdc/rabbit/test/test_publisher.py
+++ b/sdc/rabbit/test/test_publisher.py
@@ -75,13 +75,13 @@ class TestPublisher(unittest.TestCase):
         msg = 'Disconnected from queue'
         self.assertIn(msg, cm[1][-1])
 
-    def test_disconnect_error(self):
-
+    def test_disconnect_already_closed_connection(self):
+        self.publisher._connect()
         self.publisher._disconnect()
-        with self.assertLogs(level='ERROR') as cm:
+        with self.assertLogs(level='DEBUG') as cm:
             self.publisher._disconnect()
 
-        msg = 'Unable to close connection'
+        msg = 'Close called on closed connection'
         self.assertIn(msg, cm.output[0])
 
     def test_publish_message_no_connection(self):


### PR DESCRIPTION
This pull request fixes a bug where an unhandled exception in the process callable used in `on_message` could lead to the stopping of message processing, while keeping the TCP connection between the client and AMQP server alive.

New behaviour is to handle any unexpected exceptions using the Python base `Exception` class, and to nack the message that was being processed, causing the AMQP server to re-queue the message (by default sdc-rabbit uses manual acks/nacks to confirm to the server that a message has been succesfully delivered). This ensures data integrity when processing messages.
  
It also updates the version of Pika to 0.11.2.