### PR TITLE
Improving error handling around publisher connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
- - Additional exception handling in _connect of consumer
+ - Add additional exception handling in _connect of consumer
 
 ### 1.3.0 2018-01-04
  - Additional exception handling in on_message of consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+ - Additional exception handling in _connect of consumer
+
 ### 1.3.0 2018-01-04
  - Additional exception handling in on_message of consumer
  - Update Pika to 0.11.2

--- a/sdc/rabbit/publisher.py
+++ b/sdc/rabbit/publisher.py
@@ -98,11 +98,6 @@ class QueuePublisher(object):
         logger.debug("Publishing message")
         try:
             self._connect()
-        except pika.exceptions.AMQPConnectionError:
-            logger.error("Message not published. RetryableError raised")
-            raise PublishMessageError
-
-        try:
             result = self._channel.basic_publish(exchange='',
                                                  routing_key=self._queue,
                                                  mandatory=mandatory,
@@ -116,16 +111,19 @@ class QueuePublisher(object):
 
             logger.info('Published message to queue queue={}'.format(self._queue))
             return result
+        except pika.exceptions.AMQPConnectionError:
+            logger.error("Message not published. Published Message raised")
+            raise PublishMessageError
         except NackError:
             # raised when a message published in publisher-acknowledgments mode
             # is returned via `Basic.Return` followed by `Basic.Ack`.
-            logger.error("NackError occured. Message not published.")
+            logger.error("NackError occurred. Message not published.")
             raise PublishMessageError
         except UnroutableError:
             # raised when a message published in publisher-acknowledgments
             # mode is returned via `Basic.Return` followed by `Basic.Ack`.
-            logger.error("UnroutableError occured. Message not published.")
+            logger.error("UnroutableError occurred. Message not published.")
             raise PublishMessageError
         except Exception:
-            logger.exception("Unknown exception occured. Message not published.")
+            logger.exception("Unknown exception occurred. Message not published.")
             raise PublishMessageError

--- a/sdc/rabbit/publisher.py
+++ b/sdc/rabbit/publisher.py
@@ -115,7 +115,7 @@ class QueuePublisher(object):
             logger.info('Published message to queue queue={}'.format(self._queue))
             return result
         except pika.exceptions.AMQPConnectionError:
-            logger.error("Message not published. RetryableError raised")
+            logger.error("AMQPConnectionError occurred. Message not published.")
             raise PublishMessageError
         except NackError:
             # raised when a message published in publisher-acknowledgments mode

--- a/sdc/rabbit/publisher.py
+++ b/sdc/rabbit/publisher.py
@@ -101,11 +101,6 @@ class QueuePublisher(object):
         logger.debug("Publishing message")
         try:
             self._connect()
-        except pika.exceptions.AMQPConnectionError:
-            logger.error("Message not published. RetryableError raised")
-            raise PublishMessageError
-
-        try:
             result = self._channel.basic_publish(exchange='',
                                                  routing_key=self._queue,
                                                  mandatory=mandatory,
@@ -119,6 +114,9 @@ class QueuePublisher(object):
 
             logger.info('Published message to queue queue={}'.format(self._queue))
             return result
+        except pika.exceptions.AMQPConnectionError:
+            logger.error("Message not published. RetryableError raised")
+            raise PublishMessageError
         except NackError:
             # raised when a message published in publisher-acknowledgments mode
             # is returned via `Basic.Return` followed by `Basic.Ack`.


### PR DESCRIPTION
Since upgrading to Pika 0.11.2 the connect method in the publisher can now throw a socket.gaierror and we don't handle it correctly. This is causing tests to fail in sdx-collect

See differences here _flush_output:
http://pika.readthedocs.io/en/0.10.0/_modules/pika/adapters/blocking_connection.html#BlockingConnection._flush_output

http://pika.readthedocs.io/en/0.11.2/_modules/pika/adapters/blocking_connection.html#BlockingConnection._flush_output
