### PR TITLE
Bump version number to 1.5.0 and add to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### 1.5.0 2018-02-09
+ - Add additional publisher for handling fanouts to a durable exchange
+
 ### 1.4.0 2018-02-08
  - Add additional publisher for handling fanouts to an exchange
 

--- a/sdc/rabbit/__init__.py
+++ b/sdc/rabbit/__init__.py
@@ -11,4 +11,4 @@ all = [
     MessageConsumer,
 ]
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'


### PR DESCRIPTION
Bump the version number to allow a new release following the [addition of a new publisher](https://github.com/ONSdigital/sdc-rabbit/pull/50).