### PR TITLE
Hotfix - durable exchange should inherit from publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+### 1.5.1 2018-02-09
+ - Hotfix to amend DurableExchangePublisher inheritance
+
 ### 1.5.0 2018-02-09
  - Add additional publisher for handling fanouts to a durable exchange
 

--- a/sdc/rabbit/__init__.py
+++ b/sdc/rabbit/__init__.py
@@ -11,4 +11,4 @@ all = [
     MessageConsumer,
 ]
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'

--- a/sdc/rabbit/publishers.py
+++ b/sdc/rabbit/publishers.py
@@ -165,7 +165,7 @@ class ExchangePublisher(Publisher):
         return result
 
 
-class DurableExchangePublisher(Publisher):
+class DurableExchangePublisher(ExchangePublisher):
     """This is an exchange publisher that publishes response messages to a
     (durable - survives a reboot) RabbitMQ exchange.
     """

--- a/sdc/rabbit/test/test_publisher.py
+++ b/sdc/rabbit/test/test_publisher.py
@@ -4,39 +4,34 @@ from unittest import mock
 
 from pika.exceptions import AMQPConnectionError, NackError, UnroutableError
 
-from sdc.rabbit import ExchangePublisher, QueuePublisher
+from sdc.rabbit import DurableExchangePublisher, ExchangePublisher, QueuePublisher
 from sdc.rabbit.exceptions import PublishMessageError
 from sdc.rabbit.test.test_data import test_data
+
+
+good_urls = ['amqp://guest:guest@0.0.0.0:5672', 'amqp://guest:guest@0.0.0.0:5672']
+bad_urls = ['amqp://guest:guest@0.0.0.0:672', 'amqp://guest:guest@0.0.0.0:672']
+loop_urls = ['amqp://guest:guest@0.0.0.0:672', 'amqp://guest:guest@0.0.0.0:5672']
+
+queue_name = 'test_queue'
+exchange_name = 'test_exchange'
+durable_exchange_name = 'test_durable'
 
 
 class TestPublisher(unittest.TestCase):
     logger = logging.getLogger(__name__)
 
-    q_publisher = QueuePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                 'amqp://guest:guest@0.0.0.0:5672'],
-                                 'test')
+    queue_publisher = QueuePublisher(good_urls, queue_name)
+    bad_queue_publisher = QueuePublisher(bad_urls, queue_name)
+    confirm_delivery_queue_publisher = QueuePublisher(good_urls, queue_name, confirm_delivery=True)
 
-    bad_q_publisher = QueuePublisher(['amqp://guest:guest@0.0.0.0:672',
-                                     'amqp://guest:guest@0.0.0.0:672'],
-                                     'test')
+    exchange_publisher = ExchangePublisher(good_urls, exchange_name)
+    bad_exchange_publisher = ExchangePublisher(bad_urls, exchange_name)
+    confirm_delivery_exchange_publisher = ExchangePublisher(good_urls, exchange_name, confirm_delivery=True)
 
-    confirm_delivery_q_publisher = QueuePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                                  'amqp://guest:guest@0.0.0.0:5672'],
-                                                  'test',
-                                                  confirm_delivery=True)
-
-    x_publisher = ExchangePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                    'amqp://guest:guest@0.0.0.0:5672'],
-                                    'test')
-
-    bad_x_publisher = ExchangePublisher(['amqp://guest:guest@0.0.0.0:672',
-                                        'amqp://guest:guest@0.0.0.0:672'],
-                                        'test')
-
-    confirm_delivery_x_publisher = ExchangePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                                     'amqp://guest:guest@0.0.0.0:5672'],
-                                                     'test',
-                                                     confirm_delivery=True)
+    durable_exchange_publisher = DurableExchangePublisher(good_urls, durable_exchange_name)
+    bad_durable_exchange_publisher = DurableExchangePublisher(bad_urls, durable_exchange_name)
+    confirm_delivery_durable_exchange_publisher = DurableExchangePublisher(good_urls, durable_exchange_name, confirm_delivery=True)
 
     def test_incomplete_publisher(self):
         from sdc.rabbit.publishers import Publisher
@@ -44,7 +39,7 @@ class TestPublisher(unittest.TestCase):
         class BadPublisher(Publisher):
             pass
 
-        this_publisher = BadPublisher(['amqp://guest:guest@0.0.0.0:5672'])
+        this_publisher = BadPublisher(good_urls[:1])
 
         with self.assertRaises(NotImplementedError):
             this_publisher._do_publish('test')
@@ -54,35 +49,37 @@ class TestPublisher(unittest.TestCase):
             this_publisher.publish_message('test')
 
     def test_queue_init(self):
-        this_publisher = QueuePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                        'amqp://guest:guest@0.0.0.0:5672'],
-                                        'test')
-        self.assertEqual(this_publisher._urls, ['amqp://guest:guest@0.0.0.0:5672',
-                                                'amqp://guest:guest@0.0.0.0:5672'])
-        self.assertEqual(this_publisher._queue, 'test')
+        this_publisher = QueuePublisher(good_urls, queue_name)
+        self.assertEqual(this_publisher._urls, good_urls)
+        self.assertEqual(this_publisher._queue, queue_name)
         self.assertEqual(this_publisher._arguments, {})
         self.assertEqual(this_publisher._connection, None)
         self.assertEqual(this_publisher._channel, None)
+        self.assertEqual(this_publisher._durable_queue, True)
 
     def test_exchange_init(self):
-        this_publisher = ExchangePublisher(['amqp://guest:guest@0.0.0.0:5672',
-                                           'amqp://guest:guest@0.0.0.0:5672'],
-                                           'test')
-        self.assertEqual(this_publisher._urls, ['amqp://guest:guest@0.0.0.0:5672',
-                                                'amqp://guest:guest@0.0.0.0:5672'])
-        self.assertEqual(this_publisher._exchange, 'test')
+        this_publisher = ExchangePublisher(good_urls, exchange_name)
+        self.assertEqual(this_publisher._urls, good_urls)
+        self.assertEqual(this_publisher._exchange, exchange_name)
         self.assertEqual(this_publisher._arguments, {})
         self.assertEqual(this_publisher._connection, None)
         self.assertEqual(this_publisher._channel, None)
+        self.assertEqual(this_publisher._durable_exchange, False)
+
+    def test_durable_exchange_init(self):
+        this_publisher = DurableExchangePublisher(good_urls, durable_exchange_name)
+        self.assertEqual(this_publisher._urls, good_urls)
+        self.assertEqual(this_publisher._exchange, durable_exchange_name)
+        self.assertEqual(this_publisher._arguments, {})
+        self.assertEqual(this_publisher._connection, None)
+        self.assertEqual(this_publisher._channel, None)
+        self.assertEqual(this_publisher._durable_exchange, True)
 
     def test_queue_connect_loops_correctly(self):
-        this_publisher = QueuePublisher(['amqp://guest:guest@0.0.0.0:672',
-                                        'amqp://guest:guest@0.0.0.0:5672'],
-                                        'test')
+        this_publisher = QueuePublisher(loop_urls, queue_name)
 
-        self.assertEqual(this_publisher._urls, ['amqp://guest:guest@0.0.0.0:672',
-                                                'amqp://guest:guest@0.0.0.0:5672'])
-        self.assertEqual(this_publisher._queue, 'test')
+        self.assertEqual(this_publisher._urls, loop_urls)
+        self.assertEqual(this_publisher._queue, queue_name)
         self.assertEqual(this_publisher._arguments, {})
         self.assertEqual(this_publisher._connection, None)
         self.assertEqual(this_publisher._channel, None)
@@ -90,13 +87,21 @@ class TestPublisher(unittest.TestCase):
         self.assertTrue(this_publisher._connect())
 
     def test_exchange_connect_loops_correctly(self):
-        this_publisher = ExchangePublisher(['amqp://guest:guest@0.0.0.0:672',
-                                           'amqp://guest:guest@0.0.0.0:5672'],
-                                           'test')
+        this_publisher = ExchangePublisher(loop_urls, exchange_name)
 
-        self.assertEqual(this_publisher._urls, ['amqp://guest:guest@0.0.0.0:672',
-                                                'amqp://guest:guest@0.0.0.0:5672'])
-        self.assertEqual(this_publisher._exchange, 'test')
+        self.assertEqual(this_publisher._urls, loop_urls)
+        self.assertEqual(this_publisher._exchange, exchange_name)
+        self.assertEqual(this_publisher._arguments, {})
+        self.assertEqual(this_publisher._connection, None)
+        self.assertEqual(this_publisher._channel, None)
+
+        self.assertTrue(this_publisher._connect())
+
+    def test_durable_exchange_connect_loops_correctly(self):
+        this_publisher = DurableExchangePublisher(loop_urls, durable_exchange_name)
+
+        self.assertEqual(this_publisher._urls, loop_urls)
+        self.assertEqual(this_publisher._exchange, durable_exchange_name)
         self.assertEqual(this_publisher._arguments, {})
         self.assertEqual(this_publisher._connection, None)
         self.assertEqual(this_publisher._channel, None)
@@ -105,78 +110,111 @@ class TestPublisher(unittest.TestCase):
 
     def test_queue_connect_amqp_connection_error(self):
         with self.assertRaises(AMQPConnectionError):
-            self.bad_q_publisher._connect()
+            self.bad_queue_publisher._connect()
 
     def test_queue_connect_confirm_delivery_true(self):
         with self.assertLogs(level='INFO') as cm:
-            self.confirm_delivery_q_publisher._connect()
+            self.confirm_delivery_queue_publisher._connect()
 
         msg = 'Enabled delivery confirmation'
         self.assertIn(msg, cm[0][3].msg)
 
     def test_exchange_connect_amqp_connection_error(self):
         with self.assertRaises(AMQPConnectionError):
-            self.bad_x_publisher._connect()
+            self.bad_exchange_publisher._connect()
 
     def test_exchange_connect_confirm_delivery_true(self):
         with self.assertLogs(level='INFO') as cm:
-            self.confirm_delivery_x_publisher._connect()
+            self.confirm_delivery_exchange_publisher._connect()
+
+        msg = 'Enabled delivery confirmation'
+        self.assertIn(msg, cm[0][3].msg)
+
+    def test_durable_exchange_connect_amqp_connection_error(self):
+        with self.assertRaises(AMQPConnectionError):
+            self.bad_durable_exchange_publisher._connect()
+
+    def test_durable_exchange_connect_confirm_delivery_true(self):
+        with self.assertLogs(level='INFO') as cm:
+            self.confirm_delivery_durable_exchange_publisher._connect()
 
         msg = 'Enabled delivery confirmation'
         self.assertIn(msg, cm[0][3].msg)
 
     def test_queue_connect_amqpok(self):
-        result = self.q_publisher._connect()
+        result = self.queue_publisher._connect()
         self.assertEqual(result, True)
 
     def test_queue_disconnect_ok(self):
-        self.q_publisher._connect()
+        self.queue_publisher._connect()
 
         with self.assertLogs(level='DEBUG') as cm:
-            self.q_publisher._disconnect()
+            self.queue_publisher._disconnect()
 
         msg = 'Disconnected from rabbit'
         self.assertIn(msg, cm[1][-1])
 
     def test_exchange_connect_amqpok(self):
-        result = self.x_publisher._connect()
+        result = self.exchange_publisher._connect()
         self.assertEqual(result, True)
 
     def test_exchange_disconnect_ok(self):
-        self.x_publisher._connect()
+        self.exchange_publisher._connect()
 
         with self.assertLogs(level='DEBUG') as cm:
-            self.x_publisher._disconnect()
+            self.exchange_publisher._disconnect()
+
+        msg = 'Disconnected from rabbit'
+        self.assertIn(msg, cm[1][-1])
+
+    def test_durable_exchange_connect_amqpok(self):
+        result = self.durable_exchange_publisher._connect()
+        self.assertEqual(result, True)
+
+    def test_durable_exchange_disconnect_ok(self):
+        self.durable_exchange_publisher._connect()
+
+        with self.assertLogs(level='DEBUG') as cm:
+            self.durable_exchange_publisher._disconnect()
 
         msg = 'Disconnected from rabbit'
         self.assertIn(msg, cm[1][-1])
 
     def test_queue_disconnect_already_closed_connection(self):
-        self.q_publisher._connect()
-        self.q_publisher._disconnect()
+        self.queue_publisher._connect()
+        self.queue_publisher._disconnect()
         with self.assertLogs(level='DEBUG') as cm:
-            self.q_publisher._disconnect()
+            self.queue_publisher._disconnect()
 
         msg = 'Close called on closed connection'
         self.assertIn(msg, cm.output[0])
 
     def test_exchange_disconnect_already_closed_connection(self):
-        self.x_publisher._connect()
-        self.x_publisher._disconnect()
+        self.exchange_publisher._connect()
+        self.exchange_publisher._disconnect()
         with self.assertLogs(level='DEBUG') as cm:
-            self.x_publisher._disconnect()
+            self.exchange_publisher._disconnect()
+
+        msg = 'Close called on closed connection'
+        self.assertIn(msg, cm.output[0])
+
+    def test_durable_exchange_disconnect_already_closed_connection(self):
+        self.durable_exchange_publisher._connect()
+        self.durable_exchange_publisher._disconnect()
+        with self.assertLogs(level='DEBUG') as cm:
+            self.durable_exchange_publisher._disconnect()
 
         msg = 'Close called on closed connection'
         self.assertIn(msg, cm.output[0])
 
     def test_queue_publish_message_no_connection(self):
         with self.assertRaises(PublishMessageError):
-            self.bad_q_publisher.publish_message(test_data['valid'])
+            self.bad_queue_publisher.publish_message(test_data['valid'])
 
     def test_queue_publish(self):
-        self.q_publisher._connect()
+        self.queue_publisher._connect()
         with self.assertLogs(level='INFO') as cm:
-            result = self.q_publisher.publish_message(test_data['valid'])
+            result = self.queue_publisher.publish_message(test_data['valid'])
             self.assertEqual(True, result)
         self.assertIn('Published message to queue', cm.output[3])
 
@@ -184,34 +222,34 @@ class TestPublisher(unittest.TestCase):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = NackError('a')
-            self.q_publisher._connect()
+            self.queue_publisher._connect()
             with self.assertRaises(PublishMessageError):
-                self.q_publisher.publish_message(test_data['valid'])
+                self.queue_publisher.publish_message(test_data['valid'])
 
     def test_queue_publish_unroutable_error(self):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = UnroutableError('a')
-            self.q_publisher._connect()
+            self.queue_publisher._connect()
             with self.assertRaises(PublishMessageError):
-                self.q_publisher.publish_message(test_data['valid'])
+                self.queue_publisher.publish_message(test_data['valid'])
 
     def test_queue_publish_generic_error(self):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = Exception()
-            self.q_publisher._connect()
+            self.queue_publisher._connect()
             with self.assertRaises(Exception):
-                self.q_publisher.publish_message(test_data['valid'])
+                self.queue_publisher.publish_message(test_data['valid'])
 
     def test_exchange_publish_message_no_connection(self):
         with self.assertRaises(PublishMessageError):
-            self.bad_x_publisher.publish_message(test_data['valid'])
+            self.bad_exchange_publisher.publish_message(test_data['valid'])
 
     def test_exchange_publish(self):
-        self.x_publisher._connect()
+        self.exchange_publisher._connect()
         with self.assertLogs(level='INFO') as cm:
-            result = self.x_publisher.publish_message(test_data['valid'])
+            result = self.exchange_publisher.publish_message(test_data['valid'])
             self.assertEqual(True, result)
         self.assertIn('Published message to exchange', cm.output[3])
 
@@ -219,22 +257,57 @@ class TestPublisher(unittest.TestCase):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = NackError('a')
-            self.x_publisher._connect()
+            self.exchange_publisher._connect()
             with self.assertRaises(PublishMessageError):
-                self.x_publisher.publish_message(test_data['valid'])
+                self.exchange_publisher.publish_message(test_data['valid'])
 
     def test_exchange_publish_unroutable_error(self):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = UnroutableError('a')
-            self.x_publisher._connect()
+            self.exchange_publisher._connect()
             with self.assertRaises(PublishMessageError):
-                self.x_publisher.publish_message(test_data['valid'])
+                self.exchange_publisher.publish_message(test_data['valid'])
 
     def test_exchange_publish_generic_error(self):
         mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
         with mock.patch(mock_method) as barMock:
             barMock.side_effect = Exception()
-            self.x_publisher._connect()
+            self.exchange_publisher._connect()
             with self.assertRaises(Exception):
-                self.x_publisher.publish_message(test_data['valid'])
+                self.exchange_publisher.publish_message(test_data['valid'])
+
+    def test_durable_exchange_publish_message_no_connection(self):
+        with self.assertRaises(PublishMessageError):
+            self.bad_durable_exchange_publisher.publish_message(test_data['valid'])
+
+    def test_durable_exchange_publish(self):
+        self.durable_exchange_publisher._connect()
+        with self.assertLogs(level='INFO') as cm:
+            result = self.durable_exchange_publisher.publish_message(test_data['valid'])
+            self.assertEqual(True, result)
+        self.assertIn('Published message to exchange', cm.output[3])
+
+    def test_durable_exchange_publish_nack_error(self):
+        mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
+        with mock.patch(mock_method) as barMock:
+            barMock.side_effect = NackError('a')
+            self.durable_exchange_publisher._connect()
+            with self.assertRaises(PublishMessageError):
+                self.durable_exchange_publisher.publish_message(test_data['valid'])
+
+    def test_durable_exchange_publish_unroutable_error(self):
+        mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
+        with mock.patch(mock_method) as barMock:
+            barMock.side_effect = UnroutableError('a')
+            self.durable_exchange_publisher._connect()
+            with self.assertRaises(PublishMessageError):
+                self.durable_exchange_publisher.publish_message(test_data['valid'])
+
+    def test_durable_exchange_publish_generic_error(self):
+        mock_method = 'pika.adapters.blocking_connection.BlockingChannel.basic_publish'
+        with mock.patch(mock_method) as barMock:
+            barMock.side_effect = Exception()
+            self.durable_exchange_publisher._connect()
+            with self.assertRaises(Exception):
+                self.durable_exchange_publisher.publish_message(test_data['valid'])


### PR DESCRIPTION
It looks like lots but the main change is inheriting from ExchangePublisher rather than Publisher. The rest are test improvements.