### PR TITLE
Relax package version requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+ - Relax version requirements of packages
 
 ### 1.5.1 2018-02-09
  - Hotfix to amend DurableExchangePublisher inheritance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pika==0.11.2
-structlog==17.2.0
-tornado==4.5.1
-
+pika>=0.11.2
+structlog>=17.2.0
+tornado>=4.5.1

--- a/sdc/rabbit/consumers.py
+++ b/sdc/rabbit/consumers.py
@@ -79,7 +79,7 @@ class AsyncConsumer:
                 return pika.SelectConnection(pika.URLParameters(self._url),
                                              self.on_connection_open,
                                              stop_ioloop_on_close=False)
-            except pika.exceptions.AMQPConnectionError as e:
+            except pika.exceptions.AMQPConnectionError:
                 logger.exception("Connection error")
                 count += 1
                 logger.error("Connection sleep", no_of_seconds=count)
@@ -418,7 +418,7 @@ class TornadoConsumer(AsyncConsumer):
                 return pika.adapters.tornado_connection.TornadoConnection(pika.URLParameters(self._url),
                                                                           self.on_connection_open,
                                                                           stop_ioloop_on_close=False)
-            except pika.exceptions.AMQPConnectionError as e:
+            except pika.exceptions.AMQPConnectionError:
                 logger.exception("Connection error")
                 count += 1
                 logger.error("Connection sleep", no_of_seconds=count)
@@ -558,9 +558,8 @@ class MessageConsumer(TornadoConsumer):
                              action="quarantined",
                              exception=str(e),
                              tx_id=tx_id)
-            except PublishMessageError as e:
-                logger.error("Unable to publish message to quarantine queue." +
-                             " Rejecting message and requeing.")
+            except PublishMessageError:
+                logger.error("Unable to publish message to quarantine queue. Rejecting message and requeuing.")
                 self.reject_message(basic_deliver.delivery_tag,
                                     requeue=True,
                                     tx_id=tx_id)

--- a/sdc/rabbit/test/test_consumer.py
+++ b/sdc/rabbit/test/test_consumer.py
@@ -127,7 +127,7 @@ class TestSdxConsumer(unittest.TestCase):
                                                       self.body.encode('UTF-8'))
         self.assertEqual(result, None)
 
-        expected_msg = "Unable to publish message to quarantine queue. Rejecting message and requeing."
+        expected_msg = "Unable to publish message to quarantine queue. Rejecting message and requeuing."
         self.assertIn(expected_msg, cm[0][1].message)
 
     def test_on_message_bad_message_error(self):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.4.2
-responses==0.5.1
-pep8==1.6.2
-flake8==3.5.0
+coverage==4.5.2
+responses==0.10.5
+pep8==1.7.1
+flake8==3.7.6


### PR DESCRIPTION
In trying to fix a bug, I noticed that the version of pika and tornado couldn't be upgraded.
This is probably wrong, as libraries should only rarely (and with a very very good reason) pin a package to a specific version.
This relaxes it by making the currently pinned versions the minimum.  This could be changed further down the line to remove the pinning all together, but this should probably be done one step at a time to make sure nothing breaks.