### PR TITLE
Pin pika to version below 1.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+ - Pin version of pika to keep it below 1.X due to interface changes
 
 ### 1.5.2 2019-02-22
  - Relax version requirements of packages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pika>=0.11.2
+pika<1.0
 structlog>=17.2.0
 tornado>=4.5.1


### PR DESCRIPTION
The version of pika was unpinned in a previous one release.  Since then, there has been pika 1.X released, which is incompatible with how we're using it.

This PR pins it to less than 1.X so any 0.X releases that may occur will still be imported by projects using this package.